### PR TITLE
Sort hub commands

### DIFF
--- a/commands/help.go
+++ b/commands/help.go
@@ -165,13 +165,13 @@ func customCommands() []string {
 var helpText = `
 These GitHub commands are provided by hub:
 
-   pull-request   Open a pull request on GitHub
-   pr             Work with pull requests
-   fork           Make a fork of a remote repository on GitHub and add as remote
-   create         Create this repository on GitHub and add GitHub as origin
    browse         Open a GitHub page in the default browser
-   compare        Open a compare page on GitHub
-   release        List or create releases
-   issue          List or create issues
    ci-status      Show the CI status of a commit
+   compare        Open a compare page on GitHub
+   create         Create this repository on GitHub and add GitHub as origin
+   fork           Make a fork of a remote repository on GitHub and add as remote
+   issue          List or create issues
+   pr             Work with pull requests
+   pull-request   Open a pull request on GitHub
+   release        List or create releases
 `


### PR DESCRIPTION
The rest of the sections are sorted alphabetically. This makes the hub
commands easier to read by sorting them the same way.